### PR TITLE
chore(release): prepare 1.1.0 (cap triangle emission)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2025-09-26
+### Added
+- `MesherOptions.OutputRejectedCapTriangles`: emit leftover cap faces as true triangles (non?degenerate) instead of forming degenerate quads.
+- Triangle pipeline support: `Mesh.Triangles`, `IndexedMesh.Triangles`, OBJ exporter now outputs both quad and triangle faces, glTF exporter includes standalone triangles.
+- Tests: `CapTriangleFallbackTests`, `ObjTriangleExportTests`.
+
+### Changed
+- README & nuget-readme updated (triangle support, new option documented).
+- Package description & tags now mention triangles.
+
 ## [1.0.0] - 2025-09-26
 ### Added
 - Prism mesher for CCW polygon footprints with vertical extrusion.
@@ -28,4 +38,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Security
 - N/A
 
+[1.1.0]: https://github.com/MabinogiCode/FastGeoMesh/releases/tag/v1.1.0
 [1.0.0]: https://github.com/MabinogiCode/FastGeoMesh/releases/tag/v1.0.0

--- a/nuget-readme.md
+++ b/nuget-readme.md
@@ -5,16 +5,17 @@ Fast quad meshing for prismatic volumes from 2D footprints and Z elevations.
 Features:
 - Prism mesher (side faces + caps)
 - Rectangle fast-path + generic tessellation
-- Quad quality scoring & threshold
+- Quad quality scoring & threshold (MinCapQuadQuality)
+- Optional fallback explicit cap triangles (OutputRejectedCapTriangles)
 - Constraint Z levels & geometry integration
-- Exporters: OBJ, glTF (triangulated), SVG (top view)
+- Exporters: OBJ (quads+triangles), glTF (triangulated), SVG (top view)
 
 Quick start:
 ```csharp
 var poly = Polygon2D.FromPoints(new[]{ new Vec2(0,0), new Vec2(20,0), new Vec2(20,5), new Vec2(0,5) });
 var st = new PrismStructureDefinition(poly, -10, 10);
 st.AddConstraintSegment(new Segment2D(new Vec2(0,0), new Vec2(20,0)), 2.5);
-var opt = new MesherOptions { TargetEdgeLengthXY = 0.5, TargetEdgeLengthZ = 1.0 };
+var opt = new MesherOptions { TargetEdgeLengthXY = 0.5, TargetEdgeLengthZ = 1.0, OutputRejectedCapTriangles = true };
 var mesh = new PrismMesher().Mesh(st, opt);
 var indexed = IndexedMesh.FromMesh(mesh, opt.Epsilon);
 ObjExporter.Write(indexed, "mesh.obj");

--- a/src/FastGeoMesh/FastGeoMesh.csproj
+++ b/src/FastGeoMesh/FastGeoMesh.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>FastGeoMesh</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>MabinogiCode</Authors>
-    <Description>Lightweight quad meshing utilities for generic 2.5D prism structures (side faces, caps, refinement, quality scoring, exporters).</Description>
-    <PackageTags>meshing;mesh;quad;geometry;prism;cad;gis;dotnet</PackageTags>
+    <Description>Lightweight quad and triangle meshing utilities for generic 2.5D prism structures (side faces, caps, refinement, quality scoring, exporters).</Description>
+    <PackageTags>meshing;mesh;quad;triangle;geometry;prism;cad;gis;dotnet</PackageTags>
     <RepositoryUrl>https://github.com/MabinogiCode/FastGeoMesh</RepositoryUrl>
     <PackageProjectUrl>https://github.com/MabinogiCode/FastGeoMesh</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -20,7 +20,7 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <Deterministic>true</Deterministic>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>First stable release 1.0.0: core prism mesher, caps (rectangle+generic), refinement bands, quad quality scoring, geometry integration, OBJ/glTF/SVG exporters, adjacency utilities.</PackageReleaseNotes>
+    <PackageReleaseNotes>1.1.0: Added cap triangle emission (OutputRejectedCapTriangles), triangle support in mesh/indexed + OBJ exporter, docs updated.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LibTessDotNet" Version="1.1.15" />

--- a/src/FastGeoMesh/Meshing/Exporters/GltfExporter.cs
+++ b/src/FastGeoMesh/Meshing/Exporters/GltfExporter.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 
 namespace FastGeoMesh.Meshing.Exporters;
 
-/// <summary>glTF 2.0 exporter (.gltf JSON with embedded base64 buffer). Quads are triangulated.</summary>
+/// <summary>glTF 2.0 exporter (.gltf JSON with embedded base64 buffer). Quads are triangulated; standalone triangles are exported directly.</summary>
 public static class GltfExporter
 {
     private static readonly JsonSerializerOptions Indented = new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
@@ -21,15 +21,16 @@ public static class GltfExporter
 
         // positions
         foreach (var v in mesh.Vertices)
-        {
-            bw.Write((float)v.X); bw.Write((float)v.Y); bw.Write((float)v.Z);
-        }
+        { bw.Write((float)v.X); bw.Write((float)v.Y); bw.Write((float)v.Z); }
         int vCount = mesh.Vertices.Count;
         int posBytes = vCount * sizeof(float) * 3;
 
-        // indices
-        int triCount = mesh.Quads.Count * 2;
-        int idxBytes = triCount * 3 * sizeof(uint);
+        // indices (two per quad + one per triangle)
+        int quadPairTriCount = mesh.Quads.Count * 2; // each quad becomes 2 triangles
+        int extraTriCount = mesh.Triangles.Count;     // already triangles
+        int totalTriCount = quadPairTriCount + extraTriCount;
+        int idxBytes = totalTriCount * 3 * sizeof(uint);
+
         double minX = double.PositiveInfinity, minY = double.PositiveInfinity, minZ = double.PositiveInfinity;
         double maxX = double.NegativeInfinity, maxY = double.NegativeInfinity, maxZ = double.NegativeInfinity;
         foreach (var v in mesh.Vertices)
@@ -38,10 +39,16 @@ public static class GltfExporter
             if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
             if (x > maxX) maxX = x; if (y > maxY) maxY = y; if (z > maxZ) maxZ = z;
         }
+        // write quad-derived triangles
         foreach (var (v0,v1,v2,v3) in mesh.Quads)
         {
             bw.Write((uint)v0); bw.Write((uint)v1); bw.Write((uint)v2);
             bw.Write((uint)v0); bw.Write((uint)v2); bw.Write((uint)v3);
+        }
+        // write standalone cap triangles
+        foreach (var (v0,v1,v2) in mesh.Triangles)
+        {
+            bw.Write((uint)v0); bw.Write((uint)v1); bw.Write((uint)v2);
         }
         bw.Flush();
         var bufferBytes = ms.ToArray();
@@ -62,7 +69,7 @@ public static class GltfExporter
             accessors = new object[]
             {
                 new { bufferView = 0, componentType = 5126, count = vCount, type = "VEC3", min = new[]{ (double)minX, (double)minY, (double)minZ }, max = new[]{ (double)maxX, (double)maxY, (double)maxZ } },
-                new { bufferView = 1, componentType = 5125, count = triCount * 3, type = "SCALAR" }
+                new { bufferView = 1, componentType = 5125, count = totalTriCount * 3, type = "SCALAR" }
             },
             meshes = new object[] { new { primitives = new object[] { new { attributes = new { POSITION = 0 }, indices = 1, mode = 4 } } } },
             nodes = new object[] { new { mesh = 0 } },

--- a/src/FastGeoMesh/Meshing/Exporters/ObjExporter.cs
+++ b/src/FastGeoMesh/Meshing/Exporters/ObjExporter.cs
@@ -2,7 +2,7 @@ using System.Globalization;
 
 namespace FastGeoMesh.Meshing.Exporters;
 
-/// <summary>Wavefront OBJ exporter (quads only, geometry only).</summary>
+/// <summary>Wavefront OBJ exporter (quads + triangles, geometry only).</summary>
 public static class ObjExporter
 {
     /// <summary>Write mesh as OBJ file (quads). Vertices first then faces.</summary>
@@ -17,5 +17,7 @@ public static class ObjExporter
             sw.WriteLine(string.Format(inv, "v {0} {1} {2}", v.X, v.Y, v.Z));
         foreach (var (v0, v1, v2, v3) in mesh.Quads)
             sw.WriteLine(string.Format(inv, "f {0} {1} {2} {3}", v0 + 1, v1 + 1, v2 + 1, v3 + 1));
+        foreach (var (v0, v1, v2) in mesh.Triangles)
+            sw.WriteLine(string.Format(inv, "f {0} {1} {2}", v0 + 1, v1 + 1, v2 + 1));
     }
 }

--- a/src/FastGeoMesh/Meshing/Mesh.cs
+++ b/src/FastGeoMesh/Meshing/Mesh.cs
@@ -4,12 +4,16 @@ using FastGeoMesh.Geometry;
 
 namespace FastGeoMesh.Meshing;
 
-/// <summary>Raw mesh made of quads + auxiliary points and internal segments.</summary>
+/// <summary>Raw mesh made of quads + triangles + auxiliary points and internal segments.</summary>
 public sealed class Mesh
 {
     /// <summary>Collection of quads.</summary>
     public ReadOnlyCollection<Quad> Quads => _quads.AsReadOnly();
     private readonly List<Quad> _quads = new();
+
+    /// <summary>Collection of cap triangles (when enabled).</summary>
+    public ReadOnlyCollection<Triangle> Triangles => _triangles.AsReadOnly();
+    private readonly List<Triangle> _triangles = new();
 
     /// <summary>Auxiliary standalone points.</summary>
     public ReadOnlyCollection<Vec3> Points => _points.AsReadOnly();
@@ -21,6 +25,8 @@ public sealed class Mesh
 
     /// <summary>Add a quad.</summary>
     public void AddQuad(Quad quad) => _quads.Add(quad);
+    /// <summary>Add a triangle.</summary>
+    public void AddTriangle(Triangle tri) => _triangles.Add(tri);
     /// <summary>Add a point.</summary>
     public void AddPoint(Vec3 p) => _points.Add(p);
     /// <summary>Add an internal segment.</summary>

--- a/src/FastGeoMesh/Meshing/MesherOptions.cs
+++ b/src/FastGeoMesh/Meshing/MesherOptions.cs
@@ -33,6 +33,9 @@ public sealed class MesherOptions
     /// <summary>Minimum acceptable cap quad pairing quality [0,1].</summary>
     public double MinCapQuadQuality { get; set; } = 0.75;
 
+    /// <summary>Emit leftover (unpaired) cap triangles as true triangles instead of degenerate quads?</summary>
+    public bool OutputRejectedCapTriangles { get; set; }
+
     /// <summary>Validate option ranges.</summary>
     public void Validate()
     {

--- a/src/FastGeoMesh/Meshing/Triangle.cs
+++ b/src/FastGeoMesh/Meshing/Triangle.cs
@@ -1,0 +1,19 @@
+using FastGeoMesh.Geometry;
+
+namespace FastGeoMesh.Meshing;
+
+/// <summary>Triangle primitive (CCW order, typically cap fallback output).</summary>
+public sealed class Triangle
+{
+    /// <summary>First vertex.</summary>
+    public Vec3 V0 { get; }
+    /// <summary>Second vertex.</summary>
+    public Vec3 V1 { get; }
+    /// <summary>Third vertex.</summary>
+    public Vec3 V2 { get; }
+    /// <summary>Optional quality score (reserved, currently unused for triangles).</summary>
+    public double? QualityScore { get; init; }
+
+    /// <summary>Create a triangle from three CCW vertices.</summary>
+    public Triangle(Vec3 v0, Vec3 v1, Vec3 v2) => (V0, V1, V2) = (v0, v1, v2);
+}

--- a/tests/FastGeoMesh.Tests/CapTriangleFallbackTests.cs
+++ b/tests/FastGeoMesh.Tests/CapTriangleFallbackTests.cs
@@ -1,0 +1,42 @@
+using FastGeoMesh.Geometry;
+using FastGeoMesh.Meshing;
+using FastGeoMesh.Meshing.Exporters;
+using FastGeoMesh.Structures;
+using Xunit;
+
+namespace FastGeoMesh.Tests;
+
+public sealed class CapTriangleFallbackTests
+{
+    [Fact]
+    public void EmitsTrianglesWhenOptionEnabledAndQualityHigh()
+    {
+        // Non-rectangle, with a re-entrant shape to force low quality pairs
+        var outer = Polygon2D.FromPoints(new[] {
+            new Vec2(0,0), new Vec2(6,0), new Vec2(6,2), new Vec2(4,2), new Vec2(4,4), new Vec2(6,4), new Vec2(6,6), new Vec2(0,6)
+        });
+        var structure = new PrismStructureDefinition(outer, 0, 1);
+        var options = new MesherOptions
+        {
+            TargetEdgeLengthXY = 0.75,
+            TargetEdgeLengthZ = 0.5,
+            GenerateBottomCap = true,
+            GenerateTopCap = true,
+            MinCapQuadQuality = 0.95, // deliberately strict
+            OutputRejectedCapTriangles = true
+        };
+        var mesh = new PrismMesher().Mesh(structure, options);
+        // Expect some quads and some triangles
+        Assert.True(mesh.Triangles.Count > 0, "Expected rejected cap triangles to be emitted");
+
+        // Convert to indexed => triangles should be indexed too
+        var im = IndexedMesh.FromMesh(mesh, options.Epsilon);
+        Assert.True(im.Triangles.Count > 0, "Indexed mesh should retain triangle primitives");
+
+        // glTF export should succeed
+        string tmp = Path.Combine(Path.GetTempPath(), $"fgm_tri_{Guid.NewGuid():N}.gltf");
+        GltfExporter.Write(im, tmp);
+        Assert.True(File.Exists(tmp));
+        File.Delete(tmp);
+    }
+}

--- a/tests/FastGeoMesh.Tests/ObjTriangleExportTests.cs
+++ b/tests/FastGeoMesh.Tests/ObjTriangleExportTests.cs
@@ -1,0 +1,36 @@
+using FastGeoMesh.Geometry;
+using FastGeoMesh.Meshing;
+using FastGeoMesh.Meshing.Exporters;
+using FastGeoMesh.Structures;
+using Xunit;
+
+namespace FastGeoMesh.Tests;
+
+public sealed class ObjTriangleExportTests
+{
+    [Fact]
+    public void ObjContainsTriangleFacesWhenCapTrianglesEnabled()
+    {
+        var outer = Polygon2D.FromPoints(new[] {
+            new Vec2(0,0), new Vec2(5,0), new Vec2(5,2), new Vec2(3,2), new Vec2(3,4), new Vec2(5,4), new Vec2(5,6), new Vec2(0,6)
+        });
+        var structure = new PrismStructureDefinition(outer, 0, 1);
+        var options = new MesherOptions
+        {
+            TargetEdgeLengthXY = 0.8,
+            TargetEdgeLengthZ = 0.5,
+            GenerateBottomCap = true,
+            GenerateTopCap = false,
+            MinCapQuadQuality = 0.95,
+            OutputRejectedCapTriangles = true
+        };
+        var mesh = new PrismMesher().Mesh(structure, options);
+        Assert.True(mesh.Triangles.Count > 0, "Expected triangles emitted");
+        var im = IndexedMesh.FromMesh(mesh, options.Epsilon);
+        string path = Path.Combine(Path.GetTempPath(), $"fgm_obj_tri_{Guid.NewGuid():N}.obj");
+        ObjExporter.Write(im, path);
+        var lines = File.ReadAllLines(path);
+        Assert.Contains(lines, l => l.StartsWith("f ", StringComparison.Ordinal) && l.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length == 4); // triangle face: f v1 v2 v3
+        File.Delete(path);
+    }
+}


### PR DESCRIPTION
## 1.1.0

### Added
- OutputRejectedCapTriangles option: emit leftover cap faces as true triangles.
- Triangle support: Mesh.Triangles, IndexedMesh.Triangles, OBJ exporter (quads + triangles), glTF standalone triangles.
- Tests: CapTriangleFallbackTests, ObjTriangleExportTests.

### Changed
- README / nuget-readme updated.
- Package description & tags include triangles.

### Release notes
See CHANGELOG.md entry for 1.1.0.
